### PR TITLE
release: Add VOLK 2.3.0 release news

### DIFF
--- a/content/news/release-2.3.0.md
+++ b/content/news/release-2.3.0.md
@@ -1,0 +1,81 @@
+title: Release v2.3.0
+author: Johannes Demel
+date: 05-09-2020
+summary: VOLK release v2.3.0
+
+Hi everyone!
+
+VOLK 2.3 is out! We want to thank all contributors. This release wouldn't have been possible without them. We saw lots of great improvements.
+
+On GNU Radio 'master' VOLK was finally removed as a submodule.
+
+Currently we see ongoing discussions on how to improve CPU feature detection because VOLK is not as reliable as we'd like it to be in that department. We'd like to benefit from other open source projects and don't want to reinvent the wheel. Thus, one approach would be to include `cpu_features` as a submodule.
+
+### Highlights
+
+* Better reproducible builds
+* CMake improvements
+    - ORC is removed from the public interface where it was never supposed to be.
+    - CMake fixes for better usability
+* Updated and new CI chain
+    - TravisCI moved to new distro and does more tests for newer GCC/Clang
+    - Github Actions
+        - Add Action to check proper code formatting.
+        - Add CI that also runs on MacOS with XCode.
+* Enforce C/C++ coding style via clang-format
+* Kernel fixes
+    - Add puppet for `power_spectral_density` kernel
+    - Treat the `mod_range` puppet as a puppet for correct use with `volk_profile`
+    - Fix `index_max` kernels
+    - Fix `rotator`. We hope that we finally found the root cause of the issue.
+* Kernel optimizations
+    - Updated log10 calcs to use faster log2 approach
+    - Optimize `complexmultiplyconjugate`
+* New kernels
+    - accurate exp kernel is finally merged after years
+    - Add 32f_s32f_add_32f kernel to perform vector + scalar float operation
+
+### Contributors
+
+* Bernhard M. Wiedemann <bwiedemann@suse.de>
+* Clayton Smith <argilo@gmail.com>
+* Johannes Demel <demel@ant.uni-bremen.de> <demel@uni-bremen.de>
+* Michael Dickens <michael.dickens@ettus.com>
+* Tom Rondeau <tom@trondeau.com>
+* Vasil Velichkov <vvvelichkov@gmail.com>
+* ghostop14 <ghostop14@gmail.com>
+
+### Changes
+
+* Reproducible builds
+    - Drop compile-time CPU detection
+    - Drop another instance of compile-time CPU detection
+* CI updates
+    - ci: Add Github CI Action
+    - ci: Remove Ubuntu 16.04 GCC5 test on TravisCI
+    - TravisCI: Update CI to bionic distro
+    - TravisCI: Add GCC 8 test
+    - TravisCI: Structure CI file
+    - TravisCI: Clean-up .travis.yml
+* Enforce C/C++ coding style
+    - clang-format: Apply clang-format
+    - clang-format: Update PR with GitHub Action
+    - clang-format: Rebase onto current master
+* Fix compiler warnings
+    - shadow: rebase kernel fixes
+    - shadow: rebase volk_profile fix
+* CMake
+    - cmake: Remove the ORC from the VOLK public link interface
+    - versioning: Remove .Maint from libvolk version
+    - Fix endif macro name in comment
+* Kernels
+    - volk: accurate exp kernel
+        - exp: Rename SSE4.1 to SSE2 kernel
+    - Add 32f_s32f_add_32f kernel
+        - This kernel adds in vector + scalar functionality
+    - Fix the broken index max kernels
+    - Treat the mod_range puppet as such
+    - Add puppet for power spectral density kernel
+    - Updated log10 calcs to use faster log2 approach
+    - fix: Use unaligned load
+    - divide: Optimize complexmultiplyconjugate

--- a/content/pages/releases.md
+++ b/content/pages/releases.md
@@ -1,8 +1,9 @@
 title: releases
 save_as: releases.html
 
-| Date                                             | Version | archive (md5sum)                                                                          | detatched signature                                          |
+| Date                                             | Version | archive (md5sum)                                                                          | detached signature                                          |
 |--------------------------------------------------|---------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| [2020 May 9](../release-v230.html)               | v2.3.0  | [volk-2.3.0.tar.gz](../releases/volk-2.3.0.tar.gz) \(0d64902c9e8851fffd809fea1402894e\)   | [2.3.0.sha256.sig](../releases/2.3.0.sha256.sig)       
 | [2020 February 24](../release-v221.html)         | v2.2.1  | [volk-2.2.1.tar.gz](../releases/volk-2.2.1.tar.gz) \(04a602e00300959461c644699a4937df\)   | [2.2.1.sha256.sig](../releases/2.2.1.sha256.sig)       
 | [2020 February 16](../release-v220.html)         | v2.2.0  | [volk-2.2.0.tar.gz](../releases/volk-2.2.0.tar.gz) \(f2919bdaad24ed076d658f5bbdd05525\)   | [2.2.0.sha256.sig](../releases/2.2.0.sha256.sig)             |
 | [2019 December 19](../release-v210.html)         | v2.1.0  | [volk-2.1.0.tar.gz](../releases/volk-2.1.0.tar.gz) \(35aa40791ff91ab843cc9b0f2a9db142\)   |                                                              |


### PR DESCRIPTION
This commit adds a news article and prepares the releases page for this
release as well. Though, the actual binaries are not yet available.