### PR TITLE
typo: Fix typos

### DIFF
--- a/content/news/release-3.0.0.md
+++ b/content/news/release-3.0.0.md
@@ -7,7 +7,7 @@ Hi everyone!
 
 This is the VOLK v3.0.0 major release! This release marks the conclusion of a long lasting effort to complete [GREP 23](https://github.com/gnuradio/greps/blob/main/grep-0023-relicense-volk.md) that proposes to change the VOLK license to LGPLv3+. We would like to thank all VOLK contributors that they allowed this re-licensing effort to complete. This release wouldn't have been possible without them.
 
-For VOLK users it is important to not that the VOLK API does NOT change in this major release. After a series of discussion we are convinced a license change justifies a major release. Thus, you may switch to VOLK 3 and enjoy the additional freedom the LGPL offers.
+For VOLK users it is important to note that the VOLK API does NOT change in this major release. After a series of discussion we are convinced a license change justifies a major release. Thus, you may switch to VOLK 3 and enjoy the additional freedom the LGPL offers.
 
 ### Motivation for the switch to LGPLv3+
 

--- a/content/pages/releases.md
+++ b/content/pages/releases.md
@@ -3,7 +3,7 @@ save_as: releases.html
 
 | Date                                             | Version | archive (md5sum)                                                                          | detached signatures                                          |
 |--------------------------------------------------|---------|-------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| [2023 January 14](../release-v300.html)          | v3.0.0  | [volk-3.0.0.tar.gz](../releases/volk-3.0.0.tar.gz) \(b3dc10f96d71d2b5ba5c46d34e2f7c03\)   | [3.0.0.sha256.sig](../releases/3.0.0.sha256.sig)/[volk-3.0.0.tar.gz.asc](../releases/volk-3.0.0.tar.gz.asc)
+| [2023 January 14](../major-release-v300.html)    | v3.0.0  | [volk-3.0.0.tar.gz](../releases/volk-3.0.0.tar.gz) \(b3dc10f96d71d2b5ba5c46d34e2f7c03\)   | [3.0.0.sha256.sig](../releases/3.0.0.sha256.sig)/[volk-3.0.0.tar.gz.asc](../releases/volk-3.0.0.tar.gz.asc)
 | [2022 September 4](../release-v252.html)         | v2.5.2  | [volk-2.5.2.tar.gz](../releases/volk-2.5.2.tar.gz) \(7872b4dde4415dab100710e3583b0af9\)   | [2.5.2.sha256.sig](../releases/2.5.2.sha256.sig)/[volk-2.5.2.tar.gz.asc](../releases/volk-2.5.2.tar.gz.asc)
 | [2022 February 12](../release-v251.html)         | v2.5.1  | [volk-2.5.1.tar.gz](../releases/volk-2.5.1.tar.gz) \(f92bd5381269d3d13c47eaccf1379bcb\)   | [2.5.1.sha256.sig](../releases/2.5.1.sha256.sig)/[volk-2.5.1.tar.gz.asc](../releases/volk-2.5.1.tar.gz.asc)
 | [2021 June 5](../release-v250.html)              | v2.5.0  | [volk-2.5.0.tar.gz](../releases/volk-2.5.0.tar.gz) \(0905b7487bf26e8aac500f1bb7a85193\)   | [2.5.0.sha256.sig](../releases/2.5.0.sha256.sig)/[volk-2.5.0.tar.gz.asc](../releases/volk-2.5.0.tar.gz.asc)


### PR DESCRIPTION
Fix a typo in the release news and a typo in the link to that news on the releases page.