### PR TITLE
Fix documentation link

### DIFF
--- a/volk-theme/templates/base.html
+++ b/volk-theme/templates/base.html
@@ -54,7 +54,7 @@
             <ul class="nav nav-pills nav-stacked">
                 <li><a href="{{ SITEURL }}/releases.html">Releases</a></li>
                 <li><a href="https://github.com/gnuradio/volk">Code Repository</a></li>
-                <li><a href="{{ SITEURL }}/docs/">Documentation</a></li>
+                <li><a href="{{ SITEURL }}/doxygen">Documentation</a></li>
             </ul>
             </div>
         </div>

--- a/volk-theme/templates/base.html
+++ b/volk-theme/templates/base.html
@@ -54,7 +54,7 @@
             <ul class="nav nav-pills nav-stacked">
                 <li><a href="{{ SITEURL }}/releases.html">Releases</a></li>
                 <li><a href="https://github.com/gnuradio/volk">Code Repository</a></li>
-                <li><a href="{{ SITEURL }}/doxygen">Documentation</a></li>
+                <li><a href="{{ SITEURL }}/doxygen/">Documentation</a></li>
             </ul>
             </div>
         </div>


### PR DESCRIPTION
The documentation link in the base template was directed to a path that doesn't exist. Corrected the path destination. It's a temporary fix until the issue is fixed on the GitHub actions. 